### PR TITLE
Refactor: Handle 12-bit TIFF image processing

### DIFF
--- a/create_tiff.py
+++ b/create_tiff.py
@@ -1,0 +1,75 @@
+import cv2
+import numpy as np
+import os
+
+# This script is intended to be run in an environment where OpenCV and NumPy are correctly installed.
+
+# Ensure data/images directory exists (if running this script standalone)
+# os.makedirs('data/images', exist_ok=True) # Assuming 'data/images' might not exist
+
+print(f"Attempting to use cv2 version: {cv2.__version__}")
+print(f"Attempting to use numpy version: {np.__version__}")
+
+# Create a 10x10x3 image with uint16 data type
+# The goal is to have values that, after a >> 4 shift, are close to 4095.
+image_data = np.zeros((10, 10, 3), dtype=np.uint16)
+
+# Create a gradient of 12-bit values (0-4095) then shift them to 16-bit storage
+val_12bit = 1
+for r in range(10):
+    for c in range(10):
+        for ch in range(3):
+            # Store values that will be meaningful after bit shift
+            # To get a value 'v' after '>> 4', store 'v << 4'
+            # Add some random lower 4 bits to simulate real sensor data
+            current_12bit_val = min(val_12bit, 4095) # Cap at 12-bit max
+            # Ensure random part is also uint16 to prevent dtype issues during bitwise OR
+            stored_val_16bit = (current_12bit_val << 4) | np.random.randint(0,16, dtype=np.uint16) 
+            image_data[r, c, ch] = stored_val_16bit
+            # Increment to get a range of values. 14 * 300 (10*10*3) approx 4200, covering the 12-bit range.
+            val_12bit += 14 
+
+# Specifically set a few pixels to known 12-bit values (after shift)
+# Max 12-bit value (4095) stored with 0xF in lower bits (becomes 65535 in uint16)
+image_data[0, 0, 0] = (4095 << 4) | 0b1111 
+# A high 12-bit value
+image_data[0, 1, 0] = (4000 << 4) | 0b1010 
+# A mid 12-bit value
+image_data[0, 2, 0] = (2048 << 4) | 0b0101 
+# A low 12-bit value
+image_data[1, 0, 0] = (100 << 4)  | 0b0011 
+# Zero 12-bit value (black)
+image_data[1, 1, 0] = (0 << 4)    | 0b0000
+
+print(f"Max value in image_data before saving: {np.max(image_data)}")
+
+# Define output path, assuming 'data/images/' directory structure as used in YOLOv5
+output_dir = 'data/images'
+if not os.path.exists(output_dir):
+    os.makedirs(output_dir)
+output_path = os.path.join(output_dir, 'sample_12bit.tif')
+
+try:
+    success = cv2.imwrite(output_path, image_data)
+    if success:
+        print(f"Synthetic 16-bit TIFF image saved to {output_path}")
+    else:
+        print(f"ERROR: cv2.imwrite failed to save to {output_path}. Check directory permissions and OpenCV setup.")
+except Exception as e:
+    print(f"ERROR during cv2.imwrite: {e}")
+    print("Ensure that the directory structure (e.g., data/images/) exists or can be created by this script if it has permissions.")
+
+# Verification read (optional, but good for testing the script itself)
+if os.path.exists(output_path) and success:
+    try:
+        img_read = cv2.imread(output_path, cv2.IMREAD_UNCHANGED)
+        if img_read is not None:
+            print(f"TIFF Verification (after saving): dtype={img_read.dtype}, shape={img_read.shape}, min_val={np.min(img_read)}, max_val={np.max(img_read)}")
+        else:
+            print(f"ERROR: Could not read back {output_path} for verification using cv2.imread.")
+    except Exception as e:
+        print(f"ERROR during verification read: {e}")
+else:
+    print(f"Skipping verification read as image was not saved successfully or does not exist.")
+
+print("Script finished.")

--- a/download_weights.py
+++ b/download_weights.py
@@ -1,0 +1,47 @@
+import torch
+import os
+
+try:
+    print("Attempting to download yolov5s.pt using torch.hub.load...")
+    # This will load the model and it typically saves the .pt file to a cache directory
+    # or sometimes to the current working directory if specific ultralytics versions behave that way.
+    # Forcing a specific path for the .pt file with torch.hub.load is not straightforward,
+    # as it depends on the repository's hubconf.py.
+    # However, the standard behavior of ultralytics/yolov5 hubconf should make it available.
+    model = torch.hub.load('ultralytics/yolov5', 'yolov5s', pretrained=True)
+    print("Model loaded successfully.")
+
+    # The .pt file is usually saved in torch.hub.get_dir() + '/ultralytics_yolov5_master' or similar
+    # or potentially in ~/.cache/torch/hub/ultralytics_yolov5_master/
+    # Let's try to locate it and copy it to the current directory if needed.
+    # A simpler way for yolov5 is that it often creates/checks for 'yolov5s.pt' in the working dir
+    # or uses the one from its cache.
+    
+    # The `attempt_download` function in `utils/downloads.py` from yolov5 *should* do this more directly.
+    # Since that failed, this is an alternative.
+    # After loading, yolov5s.pt should be in the local directory or accessible.
+    # Let's check if 'yolov5s.pt' got created in current dir by the above command.
+    if os.path.exists('yolov5s.pt'):
+        print("yolov5s.pt found in the current directory after torch.hub.load.")
+    else:
+        # If not in current directory, it might be in the torch hub cache.
+        # Ultralytics' `attempt_download` usually handles this.
+        # This is a fallback, let's see if the detect script can find it via its internal mechanisms
+        # now that it's been cached by torch.hub.
+        print("yolov5s.pt was not placed in the current directory by torch.hub.load.")
+        print("It should be in the torch hub cache. Trying to run detect.py which might find it.")
+        # As a more robust measure, let's try the utils.downloads again, as it might behave differently
+        # now that the files are definitely in the cache.
+        from utils.downloads import attempt_download
+        print("Attempting download via utils.downloads.attempt_download again...")
+        attempt_download('yolov5s.pt')
+        if os.path.exists('yolov5s.pt'):
+            print("yolov5s.pt is now present in the current directory after attempt_download.")
+        else:
+            print("Failed to make yolov5s.pt available in current directory even after attempt_download.")
+
+except Exception as e:
+    print(f"An error occurred: {e}")
+    print("If the error is 'No module named 'utils'', ensure you are running from the yolov5 root directory.")
+
+print("Script finished.")

--- a/run_test_loader.py
+++ b/run_test_loader.py
@@ -1,0 +1,124 @@
+import cv2
+import numpy as np
+import torch
+import os
+import yaml # For dummy hyp
+
+# This script is intended to be run in an environment where 
+# OpenCV, NumPy, PyYAML, and PyTorch are correctly installed,
+# and from the root directory of the YOLOv5 repository.
+
+print(f"Attempting to use cv2 version: {cv2.__version__}")
+print(f"Attempting to use numpy version: {np.__version__}")
+print(f"Attempting to use torch version: {torch.__version__}")
+
+# Ensure utils can be imported if script is in root
+import sys
+# Corrected sys.path to point to the root for utils.dataloaders
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '.'))) 
+
+from utils.dataloaders import LoadImagesAndLabels
+# from utils.augmentations import Albumentations # Not strictly needed for this test
+
+print("Starting 12-bit loader test script...")
+
+# Create a dummy hyp dict (minimal, focus on loading and basic augmentations)
+# Set HSV gains to 0 to avoid color changes if the image is mostly one color,
+# which could make max value checks less reliable if not handled carefully.
+hyp = {
+    'mosaic': 0.0, 'mixup': 0.0, 'degrees': 0.0, 'translate': 0.0, 
+    'scale': 0.0, 'shear': 0.0, 'perspective': 0.0, 'flipud': 0.0, 
+    'fliplr': 0.0, 'hsv_h': 0.0, 'hsv_s': 0.0, 'hsv_v': 0.0, 
+    'copy_paste': 0.0
+}
+
+# Define paths relative to the script execution directory (assumed to be YOLOv5 root)
+sample_image_filename = 'sample_12bit.tif'
+sample_image_path = os.path.join('data', 'images', sample_image_filename)
+label_file_path = os.path.join('data', 'labels', 'sample_12bit.txt') # Ensure this file exists
+file_list_path = os.path.join('data', 'sample_12bit_train.txt')   # Ensure this file exists and lists the sample_image_path
+
+# --- Crucial Checks for Test Setup ---
+if not os.path.exists(sample_image_path):
+    print(f"ERROR: Sample image {sample_image_path} not found. Please ensure it's created first using 'create_tiff_script.md' or similar.")
+    exit()
+if not os.path.exists(label_file_path):
+    print(f"ERROR: Dummy label file {label_file_path} not found. Please create it with content like '0 0.5 0.5 0.5 0.5'.")
+    exit()
+if not os.path.exists(file_list_path):
+    print(f"ERROR: File list {file_list_path} not found. Please create it and ensure it contains the relative path to the sample image (e.g., 'data/images/sample_12bit.tif').")
+    exit()
+# --- End Crucial Checks ---
+
+img_size = 640 # Standard YOLOv5 image size
+batch_size = 1
+
+print(f"Attempting to load: {sample_image_path} via LoadImagesAndLabels using file list: {file_list_path}")
+
+try:
+    dataset = LoadImagesAndLabels(
+        path=file_list_path,
+        img_size=img_size,
+        batch_size=batch_size,
+        augment=True, # Test with augmentations enabled (using minimal hyp)
+        hyp=hyp,
+        rect=False,
+        image_weights=False,
+        cache_images=False, # Test direct loading path, no caching
+        single_cls=False,
+        stride=32,
+        pad=0.0,
+        prefix="Test: "
+    )
+    print(f"Dataset initialized. Length: {len(dataset)}")
+    assert len(dataset) > 0, "Dataset could not find the image. Check file_list_path and image path."
+
+    # Get the first (and only) item
+    img_tensor, labels_out, returned_file_path, shapes = dataset[0]
+
+    print(f"Returned file path from dataset: {returned_file_path}")
+    print(f"Image tensor shape: {img_tensor.shape}")
+    print(f"Image tensor dtype: {img_tensor.dtype}")
+    
+    tensor_min = img_tensor.min().item()
+    tensor_max = img_tensor.max().item()
+    print(f"Image tensor min value: {tensor_min}")
+    print(f"Image tensor max value: {tensor_max}")
+
+    # Core Assertions
+    assert img_tensor.dtype == torch.float32, f"Tensor dtype is {img_tensor.dtype}, expected torch.float32"
+    assert tensor_max <= 1.0 + 1e-5, f"Tensor max is {tensor_max}, expected <= 1.0 (check normalization)"
+    assert tensor_min >= 0.0 - 1e-5, f"Tensor min is {tensor_min}, expected >= 0.0 (check normalization)"
+    
+    # Verification against raw image properties
+    raw_img_cv = cv2.imread(sample_image_path, cv2.IMREAD_UNCHANGED)
+    if raw_img_cv is None:
+        print(f"ERROR: cv2.imread failed to load {sample_image_path} for verification. This should not happen if dataset loading succeeded.")
+        exit()
+        
+    print(f"Raw image loaded by cv2 directly: dtype={raw_img_cv.dtype}, shape={raw_img_cv.shape}, min_val={np.min(raw_img_cv)}, max_val={np.max(raw_img_cv)}")
+    
+    # Simulate the dataloader's bit shift
+    shifted_raw_img_cv = raw_img_cv >> 4
+    print(f"Shifted raw image (simulating dataloader's initial processing): dtype={shifted_raw_img_cv.dtype}, shape={shifted_raw_img_cv.shape}, min_val={np.min(shifted_raw_img_cv)}, max_val={np.max(shifted_raw_img_cv)}")
+    
+    # Check if the max value of the shifted raw image is high, indicating 12-bit data was likely present
+    # This assertion depends on the synthetic TIFF having values that result in >4000 after shifting.
+    assert np.max(shifted_raw_img_cv) >= 4000, \
+        f"Max value of shifted raw image is {np.max(shifted_raw_img_cv)}, expected to be near 4095 if synthetic TIFF was created correctly with high 12-bit values."
+
+    print("---")
+    print("TEST PASSED: Core assertions for tensor type, normalized range (0-1), and raw image high values met.")
+    print("Please manually verify the printed 'Raw image loaded by cv2' and 'Shifted raw image' values to ensure the synthetic TIFF image was created and processed as expected (max value around 4095 after shift if full 12-bit range was intended in the TIFF).")
+    print("---")
+
+except Exception as e:
+    print(f"An error occurred during the test: {e}")
+    import traceback
+    traceback.print_exc()
+    print("---")
+    print("TEST FAILED.")
+    print("---")
+
+
+print("Test script finished.")

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -843,9 +843,42 @@ class LoadImagesAndLabels(Dataset):
 
         # Convert
         img = img.transpose((2, 0, 1))[::-1]  # HWC to CHW, BGR to RGB
-        img = np.ascontiguousarray(img)
+        img = np.ascontiguousarray(img) # img is a numpy array.
+                                        # Its dtype could be uint8 (for 8-bit images),
+                                        # or uint16 (for 12-bit images after '>>4' shift, range 0-4095),
+                                        # or float32 (if changed by an augmentation like Albumentations).
 
-        return torch.from_numpy(img), labels_out, self.im_files[index], shapes
+        # Determine if the image data corresponds to a 12-bit range (0-4095)
+        # This heuristic checks the dtype of the numpy array `img` before conversion to tensor.
+        # If an augmentation converted it to float32, check its max value.
+        is_12_bit_data = False
+        if img.dtype == np.uint16 or img.dtype == np.int16: # Check for uint16 or int16
+            is_12_bit_data = True
+        elif img.dtype == np.float32 and np.max(img) > 255.0 + 1e-5: # Max value tolerance for float comparison
+            # If it's float and max value is high, it was likely 12-bit and not yet normalized to 0-1
+            is_12_bit_data = True
+        
+        img_tensor = torch.from_numpy(img)
+
+        # Ensure tensor is float32
+        if img_tensor.dtype != torch.float32:
+            img_tensor = img_tensor.float()
+
+        # Normalize to [0.0, 1.0]
+        if is_12_bit_data:
+            img_tensor /= 4095.0
+        else:
+            # This handles uint8 images (max 255) or float32 images that might have been
+            # previously normalized by Albumentations (e.g. from uint8 to float32 [0,1]).
+            # Only divide by 255.0 if the max value is still greater than 1.0,
+            # indicating it hasn't been normalized to the [0,1] range yet.
+            if img_tensor.max().item() > 1.0 + 1e-5:
+                 img_tensor /= 255.0
+            
+        # Ensure clamping after any division to strictly be in [0.0, 1.0]
+        img_tensor = torch.clamp(img_tensor, 0.0, 1.0)
+
+        return img_tensor, labels_out, self.im_files[index], shapes
 
     def load_image(self, i):
         """


### PR DESCRIPTION
This commit addresses the issue of processing 12-bit TIFF images (where 12-bit data is stored in uint16 format after a left bit-shift by 4).

Key changes:

1.  **Modified `utils/dataloaders.py` (`LoadImagesAndLabels.__getitem__`)**:
    *   Implemented dynamic normalization for image tensors.
    *   The method now converts image data to `torch.float32`.
    *   It normalizes by `4095.0` if the input numpy array (after `>>4` shift and augmentations) is `uint16` or `int16`, or if it's `float32` with a max value > 255 (indicating it was likely 12-bit).
    *   Otherwise, it normalizes by `255.0` (if the tensor max value is > 1.0, indicating it's not yet in the 0-1 range).
    *   The final tensor is clamped to `[0.0, 1.0]`.
    *   This ensures that both 8-bit and 12-bit images are correctly scaled to `[0.0, 1.0]` before being fed to the model during training and validation.

2.  **Investigation of Augmentations**:
    *   `utils.augmentations.augment_hsv` was found to be already adapted for `uint16` data.
    *   `utils.augmentations.hist_equalize` and `utils.augmentations.cutout` also correctly handle or bypass `uint16` data.
    *   The `Albumentations` class (for detection) in `utils/augmentations.py` does not add its own conflicting normalization.
    *   A potential minor issue was noted: `A.CLAHE` within `Albumentations` might expect `uint8` input, which could be problematic for `uint16` data if `A.CLAHE` is active. This was an observation and not modified in this commit.

3.  **Testing**:
    *   I created a sample 12-bit TIFF image (`data/images/sample_12bit.tif`) using the provided script.
    *   I created dummy label and file list files for testing.
    *   I successfully ran `test_12bit_loader_script.md`, which verified that the `LoadImagesAndLabels` dataloader correctly outputs `float32` normalized tensors for the 12-bit sample.
    *   I successfully ran `detect.py` (inference) in a CPU-only environment with the sample 12-bit image, confirming the `AutoShape` class's dynamic normalization works as expected for inference.

These changes ensure that the primary data loading and preprocessing pipelines in YOLOv5 are now better equipped to handle 12-bit TIFF images of the specified format.