### PR TITLE
Here's the proposed fix for the normalization of 12-bit images in `va…

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -185,8 +185,20 @@ def run(
     for path, im, im0s, vid_cap, s in dataset:
         with dt[0]:
             im = torch.from_numpy(im).to(model.device)
-            im = im.half() if model.fp16 else im.float()  # uint8 to fp16/32
-            im /= 255  # 0 - 255 to 0.0 - 1.0
+            # im_dtype_original = im.dtype # Optional: Store original dtype if needed later, though max check is used here.
+            
+            im = im.half() if model.fp16 else im.float()  # Convert to float (fp16 or fp32)
+                                                          # If 'im' came from a uint16 numpy array 
+                                                          # (e.g. 12-bit TIFF data, 0-4095 range after >>4 shift), 
+                                                          # its values are still in that original range.
+                                                          # If from uint8, values are in 0-255 range.
+
+            # Determine normalization factor based on the approximate range of the float tensor values.
+            # A simple check of the max value can distinguish between 0-255 range and 0-4095 range.
+            if im.max().item() > 256.0:  # If max value suggests it's not 8-bit data (e.g. > 255 after float conversion)
+                im /= 4095.0  # Normalize 12-bit data (assumed to be 0-4095 after any prior shifts) to 0-1
+            else:
+                im /= 255.0   # Normalize 8-bit data (assumed to be 0-255) to 0-1
             if len(im.shape) == 3:
                 im = im[None]  # expand for batch dim
             if model.xml and im.shape[0] > 1:

--- a/image_analyzer.py
+++ b/image_analyzer.py
@@ -1,0 +1,18 @@
+import cv2
+import numpy as np
+
+# Define the image path
+image_path = 'data/images/2-2.tiff'
+
+# Load the image
+img = cv2.imread(image_path, cv2.IMREAD_UNCHANGED)
+
+# Check if the image loaded successfully
+if img is None:
+    print(f"Error: Could not load image at {image_path}")
+else:
+    # Print image properties
+    print(f"Image dtype: {img.dtype}")
+    print(f"Image shape: {img.shape}")
+    print(f"Minimum pixel value: {np.min(img)}")
+    print(f"Maximum pixel value: {np.max(img)}")

--- a/val.py
+++ b/val.py
@@ -332,8 +332,18 @@ def run(
             if cuda:
                 im = im.to(device, non_blocking=True)
                 targets = targets.to(device)
-            im = im.half() if half else im.float()  # uint8 to fp16/32
-            im /= 255  # 0 - 255 to 0.0 - 1.0
+            im = im.half() if half else im.float()  # Convert to float (fp16 or fp32)
+                                                  # At this point, if 'im' came from a uint16 numpy array 
+                                                  # (e.g. 12-bit TIFF data, 0-4095 range), 
+                                                  # its values are still in that original range.
+                                                  # If from uint8, values are in 0-255 range.
+
+            # Determine normalization factor based on the approximate range of the float tensor values.
+            # A simple check of the max value can distinguish between 0-255 range and 0-4095 range.
+            if im.max().item() > 256.0:  # If max value suggests it's not 8-bit data (e.g. > 255 after float conversion)
+                im /= 4095.0  # Normalize 12-bit data (assumed to be 0-4095) to 0-1
+            else:
+                im /= 255.0   # Normalize 8-bit data (assumed to be 0-255) to 0-1
             nb, _, height, width = im.shape  # batch size, channels, height, width
 
         # Inference


### PR DESCRIPTION
…l.py` and `detect.py`:

The normalization in `val.py` and `detect.py` was previously hardcoded to divide image tensors by 255.0. This is incorrect for 12-bit images that have undergone a `>>4` shift (resulting in a 0-4095 range) as handled by the `LoadImages` dataloader.

This commit modifies the normalization step in both `val.py` and `detect.py`. The image tensor (after being converted to float, but before normalization) is checked for its maximum value. If `im.max().item() > 256.0`, it is assumed to be 12-bit data (0-4095 range) and is normalized by dividing by 4095.0. Otherwise, it is assumed to be 8-bit data (0-255 range) and is normalized by dividing by 255.0.

This change should fix issues where:
- Your mAP and Recall metrics were not improving during training (as validation was using incorrect data).
- Your saved images from validation or detection runs appeared black (due to incorrect scaling).

The `utils/dataloaders.py` was not changed, as its `>>4` shift for TIFFs was confirmed to be appropriate for the sample data, and its internal normalization for `LoadImagesAndLabels` (used in `train.py`) was already correct.